### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The contents of the log file are the XML commands and assocaited responses.  Eac
 
 ## TEMPLATING
 
-This module supports using Jinja2 templates in conjuction with the creation of complex RPCs.  Template files can be located in either the program's current working directory, or template directory for this module.  A configurable search-path option will be added as an enhancement. 
+This module supports using Jinja2 templates in conjunction with the creation of complex RPCs.  Template files can be located in either the program's current working directory, or template directory for this module.  A configurable search-path option will be added as an enhancement. 
 
 There are a few options for using templates.  These are described in detail [here]().
 


### PR DESCRIPTION
@Juniper, I've corrected a typographical error in the documentation of the [py-jnpr-wlc](https://github.com/Juniper/py-jnpr-wlc) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
